### PR TITLE
Fixes arbitrary selection of regex implementation

### DIFF
--- a/makefile
+++ b/makefile
@@ -119,7 +119,7 @@ cleanall:
 
 # Shared library of non-template components:
 
-$(BUILDDIR)/libftl.so: $(BUILDDIR)/ftlKinds.o $(BUILDDIR)/ftlString.o $(BUILDDIR)/ftlHash.o $(BUILDDIR)/ftlRegex.o
+$(BUILDDIR)/libftl.so: $(BUILDDIR)/ftlKinds.o $(BUILDDIR)/ftlString.o $(BUILDDIR)/ftlHash.o $(BUILDDIR)/ftlRegex.o $(BUILDDIR)/ftlRegex_c.o
 	$(COMPILER) $(FLAGS) $(INCLUDES) $(DEFINES) $^ $(LDFLAGS) $(SOLDFLAGS) -o $@
 
 
@@ -155,7 +155,7 @@ $(BUILDDIR)/ftlSharedPtrTests.o: tests/ftlSharedPtrTests.F90 $(BUILDDIR)/ftlShar
 $(BUILDDIR)/ftlStringTests.o: tests/ftlStringTests.F90 $(BUILDDIR)/ftlString.o $(BUILDDIR)/ftlDynArrayString.o $(BUILDDIR)/Animals.o | $(BUILDDIR)
 	$(COMPILER) $(FLAGS) $(INCLUDES) $(DEFINES) -c $< -o $@
 
-$(BUILDDIR)/ftlRegexTests.o: tests/ftlRegexTests.F90 $(BUILDDIR)/ftlRegex.o | $(BUILDDIR)
+$(BUILDDIR)/ftlRegexTests.o: tests/ftlRegexTests.F90 $(BUILDDIR)/ftlRegex.o $(BUILDDIR)/ftlRegex_c.o | $(BUILDDIR)
 	$(COMPILER) $(FLAGS) $(INCLUDES) $(DEFINES) -c $< -o $@
 
 
@@ -247,6 +247,9 @@ $(BUILDDIR)/ftlString.o: src/ftlString.F90 $(BUILDDIR)/ftlHash.o $(BUILDDIR)/ftl
 
 $(BUILDDIR)/ftlRegex.o: src/ftlRegex.F90 src/configure_ftlRegex.inc $(BUILDDIR)/ftlString.o | $(BUILDDIR)
 	$(COMPILER) $(FLAGS) $(INCLUDES) $(DEFINES) $(SOFLAGS) -c $< -o $@
+
+$(BUILDDIR)/ftlRegex_c.o: src/ftlRegex_c.c | $(BUILDDIR)
+	$(CXXCOMPILER) $(DEFINES) -c $< -o $@
 
 src/configure_ftlRegex.inc: configure/configure_ftlRegex.c
 	$(CXXCOMPILER) $(DEFINES) configure/configure_ftlRegex.c -o configure/configure_ftlRegex

--- a/src/ftlRegex.F90
+++ b/src/ftlRegex.F90
@@ -110,7 +110,7 @@ module ftlRegexModule
 
    interface
 
-      function C_regcomp(preg, pattern, flags) result(status) bind(C,name='regcomp')
+      function C_regcomp(preg, pattern, flags) result(status) bind(C)
          import
          type(C_ptr)           , intent(in), value :: preg
          character(kind=C_char), intent(in)        :: pattern(*)
@@ -118,12 +118,12 @@ module ftlRegexModule
          integer(C_int)                            :: status
       end function
 
-      subroutine C_regfree(preg) bind(C,name='regfree')
+      subroutine C_regfree(preg) bind(C)
          import
          type(C_ptr), intent(in), value :: preg
       end subroutine
 
-      function C_regerror(errcode, preg, errbuf, errbuf_size) result(errlen) bind(C,name='regerror')
+      function C_regerror(errcode, preg, errbuf, errbuf_size) result(errlen) bind(C)
          import
          integer(C_int)        , intent(in) , value :: errcode
          type(C_ptr)           , intent(in) , value :: preg
@@ -132,7 +132,7 @@ module ftlRegexModule
          integer(C_size_t)                          :: errlen
       end function
 
-      function C_regexec(preg, string, nmatch, pmatch, eflags) result(status) bind(C,name='regexec')
+      function C_regexec(preg, string, nmatch, pmatch, eflags) result(status) bind(C)
          import
          type(C_ptr)           , intent(in) , value :: preg
          character(kind=C_char), intent(in)         :: string(*)

--- a/src/ftlRegex_c.c
+++ b/src/ftlRegex_c.c
@@ -1,0 +1,24 @@
+#ifdef USE_PCRE
+#include <pcreposix.h>
+#else
+#include <regex.h>
+#endif
+
+extern "C" {
+  int c_regcomp(regex_t* preg, const char* pattern, int cflags) {
+    return regcomp(preg, pattern, cflags);
+  }
+
+  void c_regfree(regex_t* preg) {
+    regfree(preg);
+  }
+
+  size_t c_regerror(int errcode, const regex_t* preg, char* errbuf, size_t errbuf_size) {
+    return regerror(errcode, preg, errbuf, errbuf_size);
+  }
+
+  int c_regexec(const regex_t* preg, const char* string, size_t nmatch, regmatch_t pmatch[], int eflags) {
+    return regexec(preg, string, nmatch, pmatch, eflags);
+  }
+}
+


### PR DESCRIPTION
Fixes Issue #7.

Here's the issue. In `ftlRegex.F90`  you have declared interfaces to C functions `regexec` and others. When you link your program with `-lpcre -lpcreposix`, the linker has two implementations of `regexec` available to it: one from the standard C library, which is linked automatically, and another one from `libpcreposix`. Which one does it bind to? I wasn't able to find any rules that regulate this, so I assume that this is undefined and implementation dependent.

This is exactly what happened to me in Issue #7: I have compiled the library with USE_PCRE=true (default) and linked with `-lpcre -lpcreposix`, but the linker still chose to bind to the implementation from `<regex.h>` and everything crashed. 

Here's what I propose to fix it: instead of binding directly to the library function `regexec` and leaving it up to the linker to decide which one, let's create our own dummy C interface and bind to it. This way we can have full control over what implementation is used by conditionally including either `<regex.h>` or `<pcreposix.h>`. This is what I implemented in the file `ftlRegex_c.c`. The `external "C"` block is necessary for successful binding, since it prevents name mangling in case this file is compiled as a c++ file. The functions in that file have the same names as Fortran interfaces to them, so simply removing the `name` attribute in `ftlRegex.F90` is sufficient to select them as binding targets. Finally, I have also modified `makefile` to include compilation of the new C file.